### PR TITLE
feat: adds page type to hierarchical posts

### DIFF
--- a/src/admin/features/content-types/components/controlled-post-types-dropdown.tsx
+++ b/src/admin/features/content-types/components/controlled-post-types-dropdown.tsx
@@ -17,7 +17,7 @@ const ControlledPostTypesDropdown: React.FC<HookFormProps & IDropdownProps> = (
 
   useEffect(() => {
     getContentTypes.execute({
-      type: 'page,post',
+      type: 'page,post,hierarchical_post',
     });
   }, []);
   return (

--- a/src/admin/features/posts/components/sites-command-bar.tsx
+++ b/src/admin/features/posts/components/sites-command-bar.tsx
@@ -30,7 +30,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
   } = usePosts();
   const history = useHistory();
 
-  const { filterPermissions } = useAuth();
+  const {filterPermissions} = useAuth();
   const snackbar = useSnackbar();
 
   const debounced = useDebouncedCallback(async (val) => {
@@ -46,10 +46,10 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
   const commandItems = useMemo<ICommandBarItemProps[]>(
     () => {
       const items = filterPermissions([
-        {
+        selectedPosts?.[0]?.type !== 'hierarchical_post' ? {
           key: 'newItem',
           text: 'New',
-          iconProps: { iconName: 'Add' },
+          iconProps: {iconName: 'Add'},
           permissions: ['sites_create'],
           disabled: selectedPosts?.[0]?.type === 'hierarchical_post',
           subMenuProps: {
@@ -76,30 +76,30 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
               }
             ]
           }
+        } : {
+          key: 'open',
+          text: 'Open',
+          iconProps: {iconName: 'OpenInNewWindow'},
+          onClick: () => {
+            history.push(`/sites/post-container/${selectedPosts?.[0]?.id}`);
+          }
         },
-        selectedPosts?.[0]?.type !== 'hierarchical_post' ? {
+        {
           key: 'edit',
           text: 'Edit',
           disabled:
             selectedPosts?.length !== 1 || selectedPosts?.[0]?.type === 'folder',
-          iconProps: { iconName: 'Edit' },
+          iconProps: {iconName: 'Edit'},
           permissions: ['sites_update'],
           onClick: () => {
             history.push(`/sites/editor/${selectedPosts?.[0]?.id}`);
-          }
-        } : {
-          key: 'open',
-          text: 'Open',
-          iconProps: { iconName: 'OpenInNewWindow' },
-          onClick: () => {
-            history.push(`/sites/post-container/${selectedPosts?.[0]?.id}`);
           }
         },
         {
           key: 'settings',
           text: 'Settings',
           disabled: selectedPosts?.length !== 1,
-          iconProps: { iconName: 'Settings' },
+          iconProps: {iconName: 'Settings'},
           permissions: ['sites_update'],
           onClick: () => {
             setStateData('updatePostOpen', true);
@@ -110,7 +110,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
           text: 'Copy',
           disabled:
             selectedPosts?.length !== 1,
-          iconProps: { iconName: 'Copy' },
+          iconProps: {iconName: 'Copy'},
           permissions: ['sites_create'],
           onClick: () => {
             setStateData('copyPostsOpen', true);
@@ -120,7 +120,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
           key: 'delete',
           text: 'Delete',
           disabled: selectedPosts?.length === 0,
-          iconProps: { iconName: 'Delete' },
+          iconProps: {iconName: 'Delete'},
           permissions: ['sites_delete'],
           onClick: () => {
             setStateData('deletePostsOpen', true);
@@ -130,7 +130,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
           key: 'quickPublish',
           text: 'Publish',
           disabled: selectedPosts?.length === 0,
-          iconProps: { iconName: 'WebPublish' },
+          iconProps: {iconName: 'WebPublish'},
           permissions: ['sites_update'],
           onClick: () => {
             setStateData('publishPostOpen', true);
@@ -140,7 +140,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
           key: 'quickUnpublish',
           text: 'Unpublish',
           disabled: selectedPosts?.length === 0,
-          iconProps: { iconName: 'UnpublishContent' },
+          iconProps: {iconName: 'UnpublishContent'},
           permissions: ['sites_update'],
           onClick: () => {
             setStateData('unpublishPostOpen', true);
@@ -164,7 +164,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
         {
           key: 'refresh',
           text: 'Refresh',
-          iconProps: { iconName: 'Refresh' },
+          iconProps: {iconName: 'Refresh'},
           onClick: () => {
             getPosts.execute({
               type: 'page,folder,fragment,hierarchical_post',
@@ -173,16 +173,17 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
           }
         }
       ]);
-      if (enableIframeEditor && selectedPosts?.[0]?.type === 'page') {
+
+      if (enableIframeEditor && ['page', 'hierarchical_post'].includes(selectedPosts?.[0]?.type)) {
         const index = items.findIndex(item => item.key === 'edit');
         if (index > -1) {
           items.splice(index, 0, {
             key: 'editFrame',
             text: 'Customize',
-            iconProps: { iconName: 'Edit' },
+            iconProps: {iconName: 'Edit'},
             permissions: ['sites_update'],
             onRender: () => {
-              return <div style={{ display: 'flex', alignItems: 'center', margin: '0 4px' }}>
+              return <div style={{display: 'flex', alignItems: 'center', margin: '0 4px'}}>
                 <PrimaryButton onClick={() => {
                   history.push(`/sites/frame/${selectedPosts?.[0]?.id}`);
                 }}>
@@ -218,7 +219,7 @@ const SitesCommandBar: React.FC<ISitesCommandBarProps> = () => {
   return (
     <CommandBar
       items={commandItems}
-      style={{ borderBottom: `1px solid ${NeutralColors.gray30}` }}
+      style={{borderBottom: `1px solid ${NeutralColors.gray30}`}}
       farItems={farToolbarItems}
     />
   );

--- a/src/admin/features/posts/pages/post-container.page.tsx
+++ b/src/admin/features/posts/pages/post-container.page.tsx
@@ -1,6 +1,6 @@
 import Heading from '@admin/components/heading';
 import { composeWrappers } from '@admin/helpers/hoc';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import { useParams } from 'react-router';
 import PostsCommandBar from '../components/posts-command-bar';
 import PostsDeleteDialog from '../components/posts-delete-dialog';
@@ -11,7 +11,6 @@ import PostSettingsDialog from '../components/post-settings-dialog';
 import PostDuplicateDialog from '@admin/features/posts/components/post-duplicate-dialog';
 import PostPublishDialog from '@admin/features/posts/components/post-publish-dialog';
 import PostUnpublishDialog from '@admin/features/posts/components/post-unpublish-dialog';
-import {IPost} from "@shared/interfaces/model";
 
 const PostContainerPage = () => {
   const params = useParams<any>();
@@ -46,7 +45,8 @@ const PostContainerPage = () => {
       });
 
       const parent = await getPost.execute(params?.postId);
-      getOneContentType.execute(parent.contentTypeId);
+      const postContentTypeId = parseInt((parent.meta as any).postContentTypeId, 10);
+      getOneContentType.execute(postContentTypeId);
     })();
   }, [params?.parentId]);
 

--- a/src/server/controllers/post.controller.ts
+++ b/src/server/controllers/post.controller.ts
@@ -168,12 +168,18 @@ app.post(
           if (!contentType) throw new BadRequestError('invalid_content_type');
         }
 
+        let meta = [];
+        if (params.meta) {
+          meta = Object.entries(params.meta).map(([key, value]) => ({ key, value }));
+        }
+
         const postObj: Partial<IPost> = {
           name: params.name,
           slug: params.slug,
           type: params?.type || 'post',
           contentType,
-          author: req?.data?.user
+          author: req?.data?.user,
+          meta
         };
 
         if(postObj.type === 'folder') {
@@ -725,7 +731,7 @@ app.get(
     const post = await retrievePostAndCompile({
       slugPath,
       versionId: versionId as string,
-    }, {allowUnpublished});
+    }, {allowUnpublished, query: req.query});
     res.send(post);
   })
 );


### PR DESCRIPTION
Adds page type to hierarchical posts. This allows for easier routing across the application, since:

/hierarchical-blogs -> returns the page content
/hierarchical-blogs/:id -> returns child blog