### PR TITLE
custom-editor-field hook not working as expected: reference custom component by type and not by name

### DIFF
--- a/src/admin/config-fields/dynamic-field.tsx
+++ b/src/admin/config-fields/dynamic-field.tsx
@@ -173,7 +173,7 @@ const DynamicField: React.FC<DynamicFieldProps> = ({ field, name }) => {
         );
       default: {
         const Component =
-          Hooks.applySyncFilters(`admin/field/${field.name}`, null, field) ??
+          Hooks.applySyncFilters(`admin/field/${field.type}`, null, field) ??
           null;
         if (!Component) return null;
         return <Component field={field} name={getName()} />;


### PR DESCRIPTION
https://github.com/burdy-io/burdy/issues/61

because field.name could be another one for each cms content type, 
I think the reference to a custom component may be done by the type which is fixed by adding the hook