### PR TITLE
feat: extend-aws-s3-driver-options (s3ForcePathStyle)

### DIFF
--- a/src/server/drivers/aws-s3-driver.ts
+++ b/src/server/drivers/aws-s3-driver.ts
@@ -27,6 +27,10 @@ export default class AwsS3FileDriver implements IFileDriver {
       options.endpoint = new AWS.Endpoint(process.env.AWS_S3_ENDPOINT);
     }
 
+    if (process.env.AWS_S3_FORCEPATHSTYLE) {
+      options.s3ForcePathStyle = Boolean(process.env.AWS_S3_FORCEPATHSTYLE);
+    }
+
     this.s3 = new AWS.S3(options);
   }
 


### PR DESCRIPTION
It would be nice to also have the possiblity to set AWS S3 option "s3ForcePathStyle" so that on-premise/hosted storage with S3 protocol support could, which to not add bucketname to domain, also be used with this driver.

Here in this branch an proposal how to allow this by setting an .env
`AWS_S3_FORCEPATHSTYLE=true`
in the using application. If the ENV is not set, there is no change ob drivers behaviour.

This would help us to use our providers object storage.