### PR TITLE
feat:  field publishedFrom is public and always filled when published

### DIFF
--- a/src/server/common/mappers.ts
+++ b/src/server/common/mappers.ts
@@ -96,6 +96,7 @@ export const mapPublicPostWithMeta = (post) => {
     name: post.name,
     slug: post.slug,
     slugPath: post.slugPath,
+    publishedFrom: post.publishedFrom,
     createdAt: post.createdAt,
     updatedAt: post.updatedAt,
     contentType: mapContentType(post.contentType),

--- a/src/server/common/mappers.ts
+++ b/src/server/common/mappers.ts
@@ -96,7 +96,6 @@ export const mapPublicPostWithMeta = (post) => {
     name: post.name,
     slug: post.slug,
     slugPath: post.slugPath,
-    publishedFrom: post.publishedFrom,
     createdAt: post.createdAt,
     updatedAt: post.updatedAt,
     contentType: mapContentType(post.contentType),

--- a/src/server/controllers/post.controller.ts
+++ b/src/server/controllers/post.controller.ts
@@ -419,15 +419,16 @@ app.put(
         if (!(posts?.length > 0)) throw new BadRequestError('invalid_ids');
 
         const qb = postRepository.createQueryBuilder('post').update(Post);
+        const now = new Date();
         if (publish) {
           qb.set({
-            publishedAt: new Date(),
+            publishedAt: now,
             status: 'published',
-            publishedFrom: publishedFrom || null,
+            publishedFrom: publishedFrom || now,
             publishedUntil: publishedUntil ? endOfDay(
               new Date(publishedUntil),
             ) : null,
-            updatedAt: new Date()
+            updatedAt: now
           });
         } else {
           qb.set({
@@ -435,7 +436,7 @@ app.put(
             status: 'draft',
             publishedFrom: null,
             publishedUntil: null,
-            updatedAt: new Date()
+            updatedAt: now
           });
         }
 


### PR DESCRIPTION
When transferring a blog from the old engine to burdy, I ran into a problem with setting the publication date for previously published posts.
When publishing, Burdy always sets the current date to publishedAt field and there is no way to set dates as of past. Also, the publishedFrom field is not always set when published.
This feature will help me use publishedFrom field in order to save chronology of posts published on my site.