### PR TITLE
Allows publishing on systems with table prefixes

### DIFF
--- a/src/server/controllers/post.controller.ts
+++ b/src/server/controllers/post.controller.ts
@@ -451,7 +451,8 @@ app.put(
           let posts = await postRepository.findByIds(ids);
           if (!(posts?.length > 0)) throw new BadRequestError('invalid_ids');
 
-        const qb = postRepository.createQueryBuilder('post').update(Post);
+        const alias = postRepository.metadata.tableName;
+        const qb = postRepository.createQueryBuilder(alias).update(Post);
         const now = new Date();
         if (publish) {
           qb.set({
@@ -485,11 +486,11 @@ app.put(
                 });
               })
             );
-            qb.where('post.id IN (:...ids)', {
+            qb.where(`${alias}.id IN (:...ids)`, {
               ids: all.map((post) => post.id),
             });
           } else {
-            qb.where('post.id IN (:...ids)', {
+            qb.where(`${alias}.id IN (:...ids)`, {
               ids: posts.map((post) => post.id),
             });
           }


### PR DESCRIPTION
Found a bug. I'm using typeorm in multiple systems sharing the same database, so I need my burdy install to have it's tables prefixed (i.e. `blog_posts`). Turns out that typeorm doesn't support table aliases when updating (and won't support them in the future): https://github.com/typeorm/typeorm/issues/1798. This PR fixes it.

I'm getting a `Unknown column 'post.id' in 'where clause` error when attempting to publish/unpublish items.

Generated query:
```sql
UPDATE `blog_post` SET `publishedAt` = '2022-01-10 03:03:15.945', `status` = 'published', `publishedFrom` = '2022-01-10 03:03:15.945', `publishedUntil` = NULL, `updatedAt` = '2022-01-10 03:03:15.945' WHERE post.id IN (1, 2, 3)
```

Steps to reproduce:
- Set up a table prefix with the `TYPEORM_ENTITY_PREFIX`
- Attempt to publish a post.